### PR TITLE
taginfo.json: add doc_url and icon_url

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -25,16 +25,6 @@
             "description": "the code of the public transport line/route"
         },
         {
-            "key": "to",
-            "object_types": ["relation"],
-            "description": "the destination of the public transport route"
-        },
-        {
-            "key": "from",
-            "object_types": ["relation"],
-            "description": "the origin of the public transport route"
-        },
-        {
             "key": "colour",
             "object_types": ["relation"],
             "description": "the colour of the public transport line/route"

--- a/taginfo.json
+++ b/taginfo.json
@@ -4,6 +4,8 @@
         "name": "Busy Hours",
         "description": "Easy editing of OpenStreetMap public transport hours",
         "project_url": "https://jungle-bus.github.io/Busy-Hours/#/",
+        "doc_url": "https://github.com/Jungle-Bus/Busy-Hours",
+        "icon_url": "https://raw.githubusercontent.com/Jungle-Bus/resources/master/logo/Logo_Jungle_Bus-Busy_Hours.png",
         "contact_name": "Noémie Lehuby",
         "contact_email": "noemie@junglebus.io"
     },

--- a/taginfo.json
+++ b/taginfo.json
@@ -27,6 +27,16 @@
             "description": "the code of the public transport line/route"
         },
         {
+            "key": "to",
+            "object_types": ["relation"],
+            "description": "the destination of the public transport route"
+        },
+        {
+            "key": "from",
+            "object_types": ["relation"],
+            "description": "the origin of the public transport route"
+        },
+        {
             "key": "colour",
             "object_types": ["relation"],
             "description": "the colour of the public transport line/route"


### PR DESCRIPTION
`to` and `from` are roles, not keys, so they shouldn't be expressed as such in the taginfo file.